### PR TITLE
Fixes GB expandable rows on missing on some overflow text fields

### DIFF
--- a/modules/Utils/GenericBrowser/GenericBrowser_0.php
+++ b/modules/Utils/GenericBrowser/GenericBrowser_0.php
@@ -1035,7 +1035,7 @@ class Utils_GenericBrowser extends Module {
 			}
 			ksort($col);
 			foreach($col as $v)
-				$out_data[] = array('label'=>'<div class="expandable">'.$v['label'].'</div>','attrs'=>$v['attrs']);
+				$out_data[] = array('label'=>'<div class="expandable expanded">'.$v['label'].'</div>','attrs'=>$v['attrs']);
 			if(isset($this->rows_jses[$i]))
 				eval_js($this->rows_jses[$i]);
 		}


### PR DESCRIPTION
The GenericBrowser was not detecting pure text fields with overflowing text and was not activating the "expand" functionality.
If "expand" functionality switched off from User Settings the rows were shown with standard height.