### PR TITLE
Enable possibility to request user confirmation before leaving edit page

### DIFF
--- a/include/epesi.js
+++ b/include/epesi.js
@@ -148,6 +148,7 @@ var Epesi = {
 		});
 	},
 	href: function(url,indicator,mode) {
+		if (!Epesi.confirmLeave.check()) return;
 		if(Epesi.procOn==0 || mode=='allow'){
 			if(indicator=='') indicator=Epesi.default_indicator;
 			Epesi.updateIndicatorText(indicator);

--- a/include/epesi.js
+++ b/include/epesi.js
@@ -20,6 +20,49 @@ function wait_while_null(id,action) {
 };
 
 var Epesi = {
+	confirmLeave: {
+		//array of form ids which require confirmation for leaving the page
+		forms:[], 
+		message:'Leave page?',
+		//checks if leaving the page is approved
+		check: function() {
+			//remove non-existent forms from the array
+			jQuery.each(this.forms, function(i, f) {
+				if (!jQuery('#'+f).length) Epesi.confirmLeave.deactivate(f);
+			});
+			//if forms array contains values means leave page confirmation is activated
+			if (this.forms.length) {
+				//take care if user disabled alert messages
+				var openTime = new Date();
+				try {
+					var confirmed = confirm(this.message);
+				} catch(e) {
+					var confirmed = true;
+				}
+				var closeTime = new Date();
+				if ((closeTime - openTime) > 350 && !confirmed) return false;
+				this.deactivate();
+			}
+			return true;
+		},
+		activate: function(f, m) {
+			this.forms.push(f);
+			this.message = m;
+			//take care if user refreshing or going to another page
+			jQuery(window).on('beforeunload', function() {
+				return Epesi.confirmLeave.message;
+			});
+		},
+		deactivate: function(f) {
+			if (arguments.length) {
+				var i = this.forms.indexOf(f);
+				if (i > -1) this.forms.splice(i, 1);				
+			}
+			else this.forms = [];
+				
+			if (!this.forms.length) jQuery(window).unbind('beforeunload');
+		}		
+	},
 	default_indicator:'loading...',
 	procOn:0,
 	client_id:0,

--- a/modules/Libs/QuickForm/QuickForm_0.php
+++ b/modules/Libs/QuickForm/QuickForm_0.php
@@ -103,7 +103,10 @@ class Libs_QuickForm extends Module {
 		$chj = '';
 		$post = '';
 		foreach ($form_name as $f) {
-			if ($submited) $pre .= "$('".addslashes($f)."').submited.value=1;";
+			if ($submited) {
+				$pre .= 'Epesi.confirmLeave.deactivate(\''.addslashes($f).'\');';
+				$pre .= "$('".addslashes($f)."').submited.value=1;";
+			}
 			$pre .= "Event.fire(document,'e:submit_form','".$f."');";
 			$pre .= str_replace('this',"$('".addslashes($f)."')",Libs_QuickFormCommon::get_on_submit_actions());
 			if ($chj) $chj .= "+'&'+";
@@ -323,12 +326,20 @@ class Libs_QuickForm extends Module {
 		$this->assign_theme('form', $t);
 		$t->display('column');
 	}
+	
 	public function display_as_row() {
 		$t = $this->init_module('Base_Theme');
 		$this->add_error_closing_buttons();
 		$this->assign_theme('form', $t);
 		$t->display('row');
 	}
-
+	
+	public function set_confirm_leave_page($activate = true, $message = null) {
+		if ($activate) {
+			$message = empty($message)? __('Leave page without saving changes?'): $message;
+			eval_js('if (Epesi.hasOwnProperty(\'confirmLeave\')) {Epesi.confirmLeave.activate(\''.addslashes($this->get_name()).'\', \''.addslashes($message).'\');}');
+		}
+		else eval_js('if (Epesi.hasOwnProperty(\'confirmLeave\')) Epesi.confirmLeave.deactivate(\''.addslashes($this->get_name()).'\');');
+	}
 }
 ?>

--- a/modules/Utils/RecordBrowser/RecordBrowserCommon_0.php
+++ b/modules/Utils/RecordBrowser/RecordBrowserCommon_0.php
@@ -255,6 +255,7 @@ class Utils_RecordBrowserCommon extends ModuleCommon {
         $final_settings[] = array('name'=>'enable_autocomplete','label'=>__('Enable autocomplete in select/multiselect at'),'type'=>'select','default'=>50, 'values'=>array(0=>__('Always'), 20=>__('%s records', array(20)), 50=>__('%s records', array(50)), 100=>__('%s records', array(100))));
         $final_settings[] = array('name'=>'grid','label'=>__('Grid edit (experimental)'),'type'=>'checkbox','default'=>0);
         $final_settings[] = array('name'=>'save_filters','label'=>__('Save filters'),'type'=>'checkbox','default'=>0);
+        $final_settings[] = array('name'=>'confirm_leave','label'=>__('Confirm before leave edit page'),'type'=>'checkbox','default'=>1);
         $final_settings[] = array('name'=>'header_default_view','label'=>__('Default data view'),'type'=>'header');
         $final_settings = array_merge($final_settings,$settings[0]);
         $final_settings[] = array('name'=>'header_auto_fav','label'=>__('Automatically add to favorites records created by me'),'type'=>'header');

--- a/modules/Utils/RecordBrowser/RecordBrowser_0.php
+++ b/modules/Utils/RecordBrowser/RecordBrowser_0.php
@@ -1244,6 +1244,9 @@ class Utils_RecordBrowser extends Module {
         self::$tab_param = $tb->get_path();
 
         $form = $this->init_module('Libs/QuickForm',null, $mode);
+        if(Base_User_SettingsCommon::get($this->get_type(), 'confirm_leave') && ($mode == 'add' || $mode == 'edit'))
+        	$form->set_confirm_leave_page();
+        
         $this->form = $form;
 
         if($mode!='add')


### PR DESCRIPTION
 Enable possibility to request confirmation before leaving page and form not submitted (modifications not saved)
Added User setting for RecordBrowser where the feature is used for "add" and "edit" modes.
Included some comments for easier understanding of the concept.

Reference:
http://forum.epesibim.com/viewtopic.php?f=7&t=2758&p=10139&hilit=not+saved#p10139

EDIT:
Tested also with the check for "dirty form" concept mentioned in the forum but does not work well when form submitted but not validated.