### PR TITLE
Added confirmation before sending Shoutbox message to all

### DIFF
--- a/modules/Apps/Shoutbox/Shoutbox_0.php
+++ b/modules/Apps/Shoutbox/Shoutbox_0.php
@@ -176,6 +176,16 @@ class Apps_Shoutbox extends Module {
     		$theme = $this->init_module('Base/Theme');
 		    $qf->assign_theme('form', $theme);
 
+		    //confirm when sending messages to all
+		   eval_js("jq('#shoutbox_button, #shoutbox_button_big').click(function() {
+      					var submit = true;
+		    			if (jq('#shoutbox_to').val() == 'all' && !confirm('".__('Send message to all?')."')) {
+         					submit = false;
+      					}
+		    
+		    			return submit;		    			
+					});");
+		   
 			//if submited
 			if($qf->validate()) {
 				 //get post group


### PR DESCRIPTION
I had the problem several times when trying to reply to a personal Shoutbox message I forget to select the user to reply to and send the message to all.
I believe this commit fixes the issue.