### PR TITLE
RB record link open tag more functionality

### DIFF
--- a/modules/Utils/RecordBrowser/RecordBrowserCommon_0.php
+++ b/modules/Utils/RecordBrowser/RecordBrowserCommon_0.php
@@ -2193,7 +2193,7 @@ class Utils_RecordBrowserCommon extends ModuleCommon {
         }
         return Module::create_href(self::get_record_href_array($tab,$id,$action)+$more);
     }
-    public static function record_link_open_tag($tab, $id, $nolink=false, $action='view'){
+    public static function record_link_open_tag($tab, $id, $nolink=false, $action='view', $more=array()){
         self::check_table_name($tab);
         $ret = '';
         if (!is_numeric($id)) {
@@ -2204,7 +2204,7 @@ class Utils_RecordBrowserCommon extends ModuleCommon {
             Utils_RecordBrowser::$access_override['tab']==$tab &&
             Utils_RecordBrowser::$access_override['id']==$id) {
             self::$del_or_a = '</a>';
-            if (!$nolink) $ret = '<a '.self::create_record_href($tab, $id, $action).'>';
+            if (!$nolink) $ret = '<a '.self::create_record_href($tab, $id, $action, $more).'>';
             else self::$del_or_a = '';
         } else {
 			$ret = '';
@@ -2224,7 +2224,7 @@ class Utils_RecordBrowserCommon extends ModuleCommon {
             $tip = $tip ? Utils_TooltipCommon::open_tag_attrs($tip) : '';
             if (!$nolink) {
                 if($has_access) {
-                    $href = self::create_record_href($tab, $id, $action);
+                    $href = self::create_record_href($tab, $id, $action, $more);
                     $ret = '<a '.$tip.' '.$href.'>'.$ret;
                     self::$del_or_a .= '</a>';
                 } else {

--- a/modules/Utils/RecordBrowser/RecordBrowser_0.php
+++ b/modules/Utils/RecordBrowser/RecordBrowser_0.php
@@ -1448,11 +1448,11 @@ class Utils_RecordBrowser extends Module {
 					if ($default_tab===($tab_counter+1) || $tb->get_tab()==($tab_counter+1)) $default_tab = $tab_counter+2;
 				} else
 					$additional_tabs++;
+				$tab_counter++;
 			}
             $cols = $row['param'];
             $last_page = $pos;
             if ($row) $label = $row['field'];
-            $tab_counter++;
         }
 		if ($default_tab!==null) $tb->set_default_tab($default_tab);
         if ($mode!='history') {
@@ -1500,7 +1500,6 @@ class Utils_RecordBrowser extends Module {
 		
         if ($this->switch_to_addon) {
     	    $this->set_module_variable('switch_to_addon',false);
-            if($tab_counter<0) $tab_counter=0;
             $ret = DB::Execute('SELECT * FROM recordbrowser_addon WHERE tab=%s AND enabled=1 ORDER BY pos', array($this->tab));
             while ($row = $ret->FetchRow()) {
                 if (ModuleManager::is_installed($row['module'])==-1) continue;
@@ -1509,8 +1508,8 @@ class Utils_RecordBrowser extends Module {
                     if (isset($result['show']) && $result['show']==false) continue;
                     $row['label'] = $result['label'];
                 }
-                if ($row['label']==$this->switch_to_addon) $this->switch_to_addon = $tab_counter;
                 $tab_counter++;
+                if ($row['label']==$this->switch_to_addon) $this->switch_to_addon = $tab_counter;
             }
             $tb->switch_tab($this->switch_to_addon);
             location(array());


### PR DESCRIPTION
Added the `$more` parameter to `Utils_RecordBrowserCommon::record_link_open_tag` method to enable passing of additional `$_REQUEST` parameters (switch_to_addon for instance)