### PR TITLE
Utils/CommonData node custom positions

### DIFF
--- a/modules/Utils/CommonData/CommonDataCommon_0.php
+++ b/modules/Utils/CommonData/CommonDataCommon_0.php
@@ -226,8 +226,11 @@ class Utils_CommonDataCommon extends ModuleCommon {
 		
 		$node = DB::GetRow('SELECT parent_id, position FROM utils_commondata_tree WHERE id=%d',array($id));		
 		
+		DB::StartTrans();
+		// move all following nodes back
 		DB::Execute('UPDATE utils_commondata_tree SET position=position-1 WHERE parent_id=%d AND position>%d',array($node['parent_id'], $node['position']));
 		DB::Execute('DELETE FROM utils_commondata_tree WHERE id=%d',array($id));
+		DB::CompleteTrans();
 	}
 
 	/**

--- a/modules/Utils/CommonData/CommonDataCommon_0.php
+++ b/modules/Utils/CommonData/CommonDataCommon_0.php
@@ -50,14 +50,18 @@ class Utils_CommonDataCommon extends ModuleCommon {
 		if(!$name) return false;
 		$pcs = explode('/',$name);
 		$id = -1;
+		$current_array = '';
 		foreach($pcs as $v) {
 			if($v==='') continue;
 			$id2 = DB::GetOne('SELECT id FROM utils_commondata_tree WHERE parent_id=%d AND akey=%s',array($id,$v));
+			$current_array .= '/';
 			if($id2===false || $id2===null) {
-				DB::Execute('INSERT INTO utils_commondata_tree(parent_id,akey,readonly) VALUES(%d,%s,%b)',array($id,$v,$readonly));
+				$pos=self::get_array_count($current_array) + 1;
+				DB::Execute('INSERT INTO utils_commondata_tree(parent_id,akey,readonly,position) VALUES(%d,%s,%b,%d)',array($id,$v,$readonly,$pos));
 				$id = DB::Insert_ID('utils_commondata_tree','id');
 			} else
 				$id=$id2;
+			$current_array .= $v;
 		}
 		return $id;
 	}
@@ -128,8 +132,9 @@ class Utils_CommonDataCommon extends ModuleCommon {
 	 * @param $array array initialization value
 	 * @param $overwrite bool whether method should overwrite if array already exists, otherwise the data will be appended
      * @param $readonly bool do not allow user to change this array from GUI
+     * @param $default_order_by_key bool order array by key instead of ordering by the submitted order
 	 */
-	public static function new_array($name,$array,$overwrite=false,$readonly=false){
+	public static function new_array($name,$array,$overwrite=false,$readonly=false,$default_order_by_key=false){
 		foreach($array as $k=>$v)
 		    if(strpos($k,'/')!==false)
 		        trigger_error('Invalid common data key: '.$k,E_USER_ERROR);
@@ -150,14 +155,20 @@ class Utils_CommonDataCommon extends ModuleCommon {
 		$qty = count($array);
 		if ($qty!=0) {
 			$qvals = array();
+			$pos=1;
 			foreach($array as $k=>$v) {
 				$qvals[] = $id;
 				$qvals[] = $k;
 				$qvals[] = $v;
 				$qvals[] = $readonly;
+				$qvals[] = $pos;
+				$pos++;
 			}
-			DB::Execute('INSERT INTO utils_commondata_tree (parent_id, akey, value, readonly) VALUES '.implode(',',array_fill(0, $qty, '(%d,%s,%s,%b)')),$qvals);
+			DB::Execute('INSERT INTO utils_commondata_tree (parent_id, akey, value, readonly, position) VALUES '.implode(',',array_fill(0, $qty, '(%d,%s,%s,%b,%d)')),$qvals);
 		}
+		if ($default_order_by_key)
+			self::reset_array_positions($name);
+		
 		return true;
 	}
 
@@ -184,7 +195,8 @@ class Utils_CommonDataCommon extends ModuleCommon {
 				if (!$overwrite) continue;
 				DB::Execute('UPDATE utils_commondata_tree SET value=%s,readonly=%b WHERE akey=%s AND parent_id=%d',array($v,$readonly,$k,$id));
 			} else {
-				DB::Execute('INSERT INTO utils_commondata_tree (parent_id, akey, value, readonly) VALUES (%d,%s,%s,%b)',array($id,$k,$v,$readonly));
+				$pos = self::get_array_count($name) + 1;
+				DB::Execute('INSERT INTO utils_commondata_tree (parent_id, akey, value, readonly, position) VALUES (%d,%s,%s,%b,%d)',array($id,$k,$v,$readonly,$pos));
 			}
 		}
 	}
@@ -211,6 +223,10 @@ class Utils_CommonDataCommon extends ModuleCommon {
 		$ret = DB::GetCol('SELECT id FROM utils_commondata_tree WHERE parent_id=%d',array($id));
 		foreach($ret as $r)
 			self::remove_by_id($r);
+		
+		$node = DB::GetRow('SELECT parent_id, position FROM utils_commondata_tree WHERE id=%d',array($id));		
+		
+		DB::Execute('UPDATE utils_commondata_tree SET position=position-1 WHERE parent_id=%d AND position>%d',array($node['parent_id'], $node['position']));
 		DB::Execute('DELETE FROM utils_commondata_tree WHERE id=%d',array($id));
 	}
 
@@ -221,34 +237,33 @@ class Utils_CommonDataCommon extends ModuleCommon {
 	 * @param boolean order by key instead of value
 	 * @return mixed returns an array if such array exists, false otherwise
 	 */
-	public static function get_array($name, $order_by_key=false, $readinfo=false, $silent=false){
+	public static function get_array($name, $order_by_position=false, $readinfo=false, $silent=false){
 		static $cache;
-		if(isset($cache[$name][$order_by_key][$readinfo]))
-			return $cache[$name][$order_by_key][$readinfo];
+		if(isset($cache[$name][$order_by_position][$readinfo]))
+			return $cache[$name][$order_by_position][$readinfo];
 		$id = self::get_id($name);
 		if($id===false)
 			if ($silent) return null;
-			else trigger_error('Invalid CommonData::get_array() request: '.$name,E_USER_ERROR);
-		if($order_by_key)
-			$order_by = 'akey ASC';
+		else trigger_error('Invalid CommonData::get_array() request: '.$name,E_USER_ERROR);
+		if($order_by_position) 
+			$order_by = ($order_by_position === 'key')? 'akey ASC': 'position ASC';
 		else
 			$order_by = 'value ASC';
 		if($readinfo)
 			$ret = DB::GetAssoc('SELECT akey, value, readonly FROM utils_commondata_tree WHERE parent_id=%d ORDER BY '.$order_by,array($id),true);
-		else 
+		else
 			$ret = DB::GetAssoc('SELECT akey, value FROM utils_commondata_tree WHERE parent_id=%d ORDER BY '.$order_by,array($id));
-		$cache[$name][$order_by_key][$readinfo] = $ret;
+		$cache[$name][$order_by_position][$readinfo] = $ret;
 		return $ret;
 	}
 
-	public static function get_translated_array($name,$order_by_key=false,$readinfo=false,$silent=false) {
-		if ($readinfo) $info = self::get_array($name,$order_by_key,$readinfo,$silent);
-		$arr = self::get_array($name,$order_by_key,false,$silent);
+	public static function get_translated_array($name,$order_by_position=false,$readinfo=false,$silent=false) {
+		if ($readinfo) $info = self::get_array($name,$order_by_position,$readinfo,$silent);
+		$arr = self::get_array($name,$order_by_position,false,$silent);
 		if ($arr===null) return null;
+		
 		$arr = self::translate_array($arr);
-		if ($order_by_key)
-			ksort($arr, SORT_LOCALE_STRING);
-		else
+		if (!$order_by_position)
 			asort($arr, SORT_LOCALE_STRING);
 		if ($readinfo) {
 			foreach ($arr as $k=>$v) {
@@ -304,6 +319,41 @@ class Utils_CommonDataCommon extends ModuleCommon {
 			}
 		}
 		return $output;
+	}
+	
+	public static function change_node_position($id, $new_pos){
+		DB::StartTrans();
+		$node = DB::GetRow('SELECT * FROM utils_commondata_tree WHERE id=%d', array($id));
+		if ($node) {
+			// move all following nodes back
+			DB::Execute('UPDATE utils_commondata_tree SET position=position-1 WHERE parent_id=%d AND position>%d',array($node['parent_id'], $node['position']));
+			// make place for moved node
+			DB::Execute('UPDATE utils_commondata_tree SET position=position+1 WHERE parent_id=%d AND position>=%d',array($node['parent_id'], $new_pos));
+			// set new node position
+			DB::Execute('UPDATE utils_commondata_tree SET position=%d WHERE id=%d',array($new_pos, $id));
+		}
+		DB::CompleteTrans();
+	}
+	
+	public static function reset_array_positions($name){
+		$arr = self::get_array($name, true);
+		
+		DB::StartTrans();
+		$pos = 1;
+		foreach ($arr as $k=>$v) {
+			$id = self::get_id($name . '/' . $k);
+			
+			DB::Execute('UPDATE utils_commondata_tree SET position=%d WHERE id=%d',array($pos, $id));
+			
+			$pos++;
+		}
+		DB::CompleteTrans();
+	}	
+	
+	public static function get_node_position($name){
+		$id = self::get_id($name . '/' . $k);
+		
+		return DB::GetOne('SELECT position FROM utils_commondata_tree WHERE id=%d', array($id));
 	}
 }
 

--- a/modules/Utils/CommonData/CommonDataCommon_0.php
+++ b/modules/Utils/CommonData/CommonDataCommon_0.php
@@ -256,6 +256,7 @@ class Utils_CommonDataCommon extends ModuleCommon {
 			$ret = DB::GetAssoc('SELECT akey, value, readonly FROM utils_commondata_tree WHERE parent_id=%d ORDER BY '.$order_by,array($id),true);
 		else
 			$ret = DB::GetAssoc('SELECT akey, value FROM utils_commondata_tree WHERE parent_id=%d ORDER BY '.$order_by,array($id));
+		if ($order_by_position === 'key') ksort($ret);
 		$cache[$name][$order_by_position][$readinfo] = $ret;
 		return $ret;
 	}
@@ -339,7 +340,7 @@ class Utils_CommonDataCommon extends ModuleCommon {
 	}
 	
 	public static function reset_array_positions($name){
-		$arr = self::get_array($name, true);
+		$arr = self::get_array($name, 'key');
 		
 		DB::StartTrans();
 		$pos = 1;

--- a/modules/Utils/CommonData/CommonData_0.php
+++ b/modules/Utils/CommonData/CommonData_0.php
@@ -91,10 +91,17 @@ class Utils_CommonData extends Module {
 	 */
 	public function browse($name='',$root=true){
 		if($this->is_back()) return false;
+		
+		if (isset($_REQUEST['node_position'])) {
+			list($node_id, $position) = $_REQUEST['node_position'];
+
+			Utils_CommonDataCommon::change_node_position($node_id, $position);
+		}
 
 		$gb = $this->init_module('Utils/GenericBrowser',null,'browse'.md5($name));
 
 		$gb->set_table_columns(array(
+						array('name'=>__('Position'),'width'=>5, 'order'=>'position'),
 						array('name'=>__('Key'),'width'=>20, 'order'=>'akey','search'=>1,'quickjump'=>'akey'),
 						array('name'=>__('Value'),'width'=>20, 'order'=>'value','search'=>1)
 					));
@@ -103,16 +110,27 @@ class Utils_CommonData extends Module {
 		$ret = Utils_CommonDataCommon::get_translated_array($name,true,true);
 		foreach($ret as $k=>$v) {
 			$gb_row = $gb->get_new_row();
-			$gb_row->add_data($k,$v['value']); // ****** CommonData value translation
+			$gb_row->add_data(Utils_CommonDataCommon::get_node_position($name.'/'.$k),$k,$v['value']); // ****** CommonData value translation
 			$gb_row->add_action($this->create_callback_href(array($this,'browse'),array($name.'/'.$k,false)),'View');
 			if(!$v['readonly']) {
 				$gb_row->add_action($this->create_callback_href(array($this,'edit'),array($name,$k)),'Edit');
 				$gb_row->add_action($this->create_confirm_callback_href(__('Delete array').' \''.Epesi::escapeJS($name.'/'.$k,false).'\'?',array('Utils_CommonData','remove_array'), array($name.'/'.$k)),'Delete');
 			}
+			$node_id = Utils_CommonDataCommon::get_id($name.'/'.$k);
+			$gb_row->add_action('class="move-handle"','Move', __('Drag to change node order'), 'move-up-down');
+			$gb_row->set_attrs("node=\"$node_id\" class=\"sortable\"");
 		}
+		
+		$gb->set_default_order(array('Position'=>'ASC'));
 		//$this->display_module($gb);
 		$this->display_module($gb,array(true),'automatic_display');
 
+		// sorting
+		load_js($this->get_module_dir() . 'sort_nodes.js');
+		$table_md5 = md5($gb->get_path());
+		eval_js("utils_commondata_sort_nodes_init(\"$table_md5\")");
+		
+		Base_ActionBarCommon::add('settings',__('Reset Order By Key'),$this->create_callback_href(array('Utils_CommonDataCommon','reset_array_positions'),$name));
 		Base_ActionBarCommon::add('add',__('Add array'),$this->create_callback_href(array($this,'edit'),$name));
 		if(!$root)
 			Base_ActionBarCommon::add('back',__('Back'),$this->create_back_href());

--- a/modules/Utils/CommonData/patches/20150428_node_position.php
+++ b/modules/Utils/CommonData/patches/20150428_node_position.php
@@ -11,6 +11,7 @@ function reset_sub_arrays($name) {
 	$arr = Utils_CommonDataCommon::get_array($name, false, false, true);
 	
 	foreach ($arr as $k=>$v) {
+		if (empty($k)) continue;
 		reset_sub_arrays($name . '/' .$k);
 	}
 }

--- a/modules/Utils/CommonData/patches/20150428_node_position.php
+++ b/modules/Utils/CommonData/patches/20150428_node_position.php
@@ -1,0 +1,18 @@
+<?php
+
+defined("_VALID_ACCESS") || die('Direct access forbidden');
+
+PatchUtil::db_add_column('utils_commondata_tree', 'position', 'I4');
+
+reset_sub_arrays('/');
+
+function reset_sub_arrays($name) {
+	Utils_CommonDataCommon::reset_array_positions($name);
+	$arr = Utils_CommonDataCommon::get_array($name, false, false, true);
+	
+	foreach ($arr as $k=>$v) {
+		reset_sub_arrays($name . '/' .$k);
+	}
+}
+
+

--- a/modules/Utils/CommonData/sort_nodes.js
+++ b/modules/Utils/CommonData/sort_nodes.js
@@ -1,0 +1,21 @@
+function utils_commondata_sort_nodes_init(table_md5) {
+    jq("#table_" + table_md5 + " tbody").sortable(
+        {
+            helper: function (e, tr) {
+                var $originals = tr.children();
+                var $helper = tr.clone();
+                $helper.children().each(function (index) {
+                    // Set helper cell sizes to match the original sizes
+                    jq(this).width($originals.eq(index).width());
+                });
+                return $helper;
+            },
+            handle: ".move-handle",
+            containment: "parent",
+            items: "> tr.sortable",
+            update: function (event, ui) {
+                _chj(jq.param({"node_position": [ui.item.attr("node"), ui.item.index()+1]}), "", "");
+            }
+        }
+    );
+}

--- a/modules/Utils/RecordBrowser/RecordBrowser_0.php
+++ b/modules/Utils/RecordBrowser/RecordBrowser_0.php
@@ -393,7 +393,9 @@ class Utils_RecordBrowser extends Module {
 					$parts = explode('::', $this->table_rows[$filter]['param']['array_id']);
 					$array_id = array_shift($parts);
 					$arr = Utils_CommonDataCommon::get_translated_array($array_id, $this->table_rows[$filter]['param']['order_by_key']);
+					$made_of_parts = false;
 					while (!empty($parts)) {
+						$made_of_parts = true;
 						array_shift($parts);
 						$next_arr = array();
 						foreach ($arr as $k=>$v) {
@@ -403,7 +405,7 @@ class Utils_RecordBrowser extends Module {
 						}
 						$arr = $next_arr;
 					}
-                    natcasesort($arr);
+                    if ($made_of_parts) natcasesort($arr);
             } else {
                     $param = explode(';',$this->table_rows[$filter]['param']);
                     $x = explode('::',$param[0]);


### PR DESCRIPTION
Added possibility to arrange CommonData nodes by custom positions.
- the patch adds positions to all arrays and orders the nodes by key for backward compatibility.
- for new CommonData arrays the order followed is the order of the array elements.
- corrected the ordering of filter selects in RecordBrowser - ordered by value only if select made up of several CommonData arrays. In other case follow the field setting