### PR TITLE
[FIX] avoid error when id=null

### DIFF
--- a/modules/Utils/RecordBrowser/RecordBrowser_0.php
+++ b/modules/Utils/RecordBrowser/RecordBrowser_0.php
@@ -1224,7 +1224,7 @@ class Utils_RecordBrowser extends Module {
 			self::$last_record = $this->record = Utils_RecordBrowserCommon::get_record($this->tab, $id, $mode!=='edit');
 		} else {
 			self::$last_record = $this->record = $id;
-			$id = intVal($this->record['id']);
+			$id = isset($this->record['id'])? intVal($this->record['id']): null;
 		}
 		if ($id===0) $id = null;
         if ($id!==null && is_numeric($id)) Utils_WatchdogCommon::notified($this->tab,$id);


### PR DESCRIPTION
Not sure what the idea was behind but php issues E_WARNING (2) Message: Illegal string offset 'id' when $id = null.
the modification should be checked for consistency with the idea behind (I guess $id may contain the full record as array)