### PR TITLE
[UPDATE] use tab as static name when jump

### DIFF
--- a/modules/Utils/RecordBrowser/RecordBrowserCommon_0.php
+++ b/modules/Utils/RecordBrowser/RecordBrowserCommon_0.php
@@ -2383,7 +2383,7 @@ class Utils_RecordBrowserCommon extends ModuleCommon {
             unset($_REQUEST['__jump_to_RB_action']);
             $x = ModuleManager::get_instance('/Base_Box|0');
             if (!$x) trigger_error('There is no base box module instance',E_USER_ERROR);
-            $x->push_main(Utils_RecordBrowser::module_name(),'view_entry_with_REQUEST',array($action, $id, array(), true, $_REQUEST),array($tab));
+            $x->push_main(Utils_RecordBrowser::module_name(),'view_entry_with_REQUEST',array($action, $id, array(), true, $_REQUEST),array($tab), $tab);
             return true;
         }
         return false;


### PR DESCRIPTION
Issue to solve: ensure column widths in addon GB tables set by user and stored in browser local storage persist over each time the record view / addon is displayed
Background: addon GB tables are assigned random id as the module path is different on each record view and column width settings are identified by GB table id
Solution: Pass the tab name to the push_main method when a RB jump to ensure static module path in record view mode.