### PR TITLE
[FIX] custom col_width_id for saving GB column widths

### DIFF
--- a/modules/Utils/GenericBrowser/GenericBrowser_0.php
+++ b/modules/Utils/GenericBrowser/GenericBrowser_0.php
@@ -30,6 +30,7 @@ class Utils_GenericBrowser extends Module {
 	public $form_s = null;
 	private $resizable_columns = true;
 	private $fixed_columns_selector = '.Utils_GenericBrowser__actions';
+	private $columns_width_id = null;
 
 	public function construct() {
 		$this->form_s = $this->init_module(Libs_QuickForm::module_name());
@@ -81,12 +82,16 @@ class Utils_GenericBrowser extends Module {
 	 * @param array $arg columns definiton
 	 */
 	public function set_table_columns(array $arg){
+		$col_names = array();
 		foreach($arg as $v) {
 			if (!is_array($v))
-				$this->columns[] = array('name' => $v);
-			else
-				$this->columns[] = $v;
+				$v = array('name' => $v);
+			
+			$this->columns[] = $v;
+			
+			$col_names[] = isset($v['name'])? $v['name']: null;
 		}
+		$this->columns_width_id = md5(serialize($col_names));
 	}
 
 	/**
@@ -1019,6 +1024,7 @@ class Utils_GenericBrowser extends Module {
 		$theme->assign('row_attrs', $this->row_attrs);
 
         $theme->assign('table_id','table_'.$md5_id);
+        $theme->assign('cols_width_id',$this->columns_width_id);
         if($expand_action_only) {
             eval_js('gb_expandable_hide_actions("'.$md5_id.'")');
         }

--- a/modules/Utils/GenericBrowser/js/col_resizable.js
+++ b/modules/Utils/GenericBrowser/js/col_resizable.js
@@ -25,7 +25,7 @@
 	var	count = 0;				//internal count to create unique IDs when needed.	
 	
 	//common strings for packing
-	var ID = "id";	
+	var ID = "cols_width_id";	
 	var PX = "px";
 	var SIGNATURE ="JColResizer";
     var FLEX = "JCLRFlex";

--- a/modules/Utils/GenericBrowser/theme/default.tpl
+++ b/modules/Utils/GenericBrowser/theme/default.tpl
@@ -101,7 +101,7 @@
 		<div class="css3_content_shadow">
 			<div class="margin2px">
 				{$table_prefix}
-                {capture name="table_attr"}id="{$table_id}" class="Utils_GenericBrowser" cellspacing="0" cellpadding="0" style="width:100%;table-layout:fixed;overflow:hidden;text-overflow:ellipsis;"{/capture}
+                {capture name="table_attr"}id="{$table_id}" cols_width_id="{$cols_width_id}" class="Utils_GenericBrowser" cellspacing="0" cellpadding="0" style="width:100%;table-layout:fixed;overflow:hidden;text-overflow:ellipsis;"{/capture}
 				{html_table_epesi table_attr=$smarty.capture.table_attr loop=$data cols=$cols row_attrs=$row_attrs}
 				{$table_postfix}
 


### PR DESCRIPTION
Create and use a custom id for saving column widths. ID is based on the column names and assumes that if same group of column names set then same widths should be set.