### PR TITLE
[UPDATE] generic method for linked text with tooltip

### DIFF
--- a/modules/Utils/RecordBrowser/RecordBrowserCommon_0.php
+++ b/modules/Utils/RecordBrowser/RecordBrowserCommon_0.php
@@ -1985,7 +1985,9 @@ class Utils_RecordBrowserCommon extends ModuleCommon {
     	return self::record_link_open_tag_r($tab, $record, $nolink) .
     			$text . self::record_link_close_tag();
     }
- 	public static function create_linked_text($text, $tab, $id, $nolink=false, $tooltip=true){
+	public static function create_linked_text($text, $tab, $id, $nolink=false, $tooltip=true){
+		if ($nolink) return $text;
+		
     	if (!is_numeric($id)) return '';
     	
     	$text = self::create_record_tooltip($text, $tab, $id, $nolink, $tooltip);

--- a/modules/Utils/RecordBrowser/RecordBrowserCommon_0.php
+++ b/modules/Utils/RecordBrowser/RecordBrowserCommon_0.php
@@ -1980,21 +1980,21 @@ class Utils_RecordBrowserCommon extends ModuleCommon {
     		if (empty($record_vals[$field])) continue;
     		$vals[] = $record_vals[$field];
     	}
-    	$text = self::create_record_tooltip(implode(' ', $vals), $tab, $id, $tooltip);
-    	
+    	$text = self::create_record_tooltip(implode(' ', $vals), $tab, $id, $nolink, $tooltip);
+
     	return self::record_link_open_tag_r($tab, $record, $nolink) .
     			$text . self::record_link_close_tag();
     }
  	public static function create_linked_text($text, $tab, $id, $nolink=false, $tooltip=true){
     	if (!is_numeric($id)) return '';
     	
-    	$open_tag = self::record_link_open_tag($tab, $id, $nolink);
-    	$close_tag = self::record_link_close_tag();
+    	$text = self::create_record_tooltip($text, $tab, $id, $nolink, $tooltip);
     	
-    	return $open_tag . self::create_record_tooltip($text, $tab, $id, $tooltip) . $close_tag;
+    	return self::record_link_open_tag($tab, $id, $nolink) . 
+    			$text . self::record_link_close_tag();
     }
-    public static function create_record_tooltip($text, $tab, $id, $tooltip=true){
-    	if (!$tooltip || Utils_TooltipCommon::is_tooltip_code_in_str($text))
+    public static function create_record_tooltip($text, $tab, $id, $nolink=false, $tooltip=true){
+    	if (!$tooltip || $nolink || Utils_TooltipCommon::is_tooltip_code_in_str($text)) 
     		return $text;
     	 
     	if (!is_array($tooltip))
@@ -2144,7 +2144,7 @@ class Utils_RecordBrowserCommon extends ModuleCommon {
             if ($r[$col])
                 $vals[] = $r[$col];
         }        
-        $text = self::create_record_tooltip(implode(' ', $vals), $tab, $r['id'], $tooltip);
+        $text = self::create_record_tooltip(implode(' ', $vals), $tab, $r['id'], $nolink, $tooltip);
         
         return $open_tag . $text . $close_tag;
     }

--- a/modules/Utils/RecordBrowser/RecordBrowserCommon_0.php
+++ b/modules/Utils/RecordBrowser/RecordBrowserCommon_0.php
@@ -1985,14 +1985,13 @@ class Utils_RecordBrowserCommon extends ModuleCommon {
     	return self::record_link_open_tag_r($tab, $record, $nolink) .
     			$text . self::record_link_close_tag();
     }
-    public static function create_linked_text($text, $tab, $id, $nolink=false, $tooltip=true){
+ 	public static function create_linked_text($text, $tab, $id, $nolink=false, $tooltip=true){
     	if (!is_numeric($id)) return '';
-    	 
-    	$ret = self::record_link_open_tag($tab, $id);
-    	$ret .= self::create_record_tooltip($text, $tab, $id, $tooltip);
-    	$ret .= self::record_link_close_tag();
-    	 
-    	return $ret;
+    	
+    	$open_tag = self::record_link_open_tag($tab, $id, $nolink);
+    	$close_tag = self::record_link_close_tag();
+    	
+    	return $open_tag . self::create_record_tooltip($text, $tab, $id, $tooltip) . $close_tag;
     }
     public static function create_record_tooltip($text, $tab, $id, $tooltip=true){
     	if (!$tooltip || Utils_TooltipCommon::is_tooltip_code_in_str($text))


### PR DESCRIPTION
A method for a frequently used feature: a linked text with tooltip
Tooltip variable controls the display of the tooltip:
- false: no tooltip
- true: default record tooltip
- array with settings: tooltip is displayed based on the settings
The tooltip option added also to create_linked_label and create_linked_label_r methods.