### PR TITLE
[UPDATE] remove legacy code and make order option for commondata more intuitive

### DIFF
--- a/modules/Base/Notify/NotifyCommon_0.php
+++ b/modules/Base/Notify/NotifyCommon_0.php
@@ -189,7 +189,7 @@ class Base_NotifyCommon extends ModuleCommon {
 				array('name'=>null,'label'=>__('General'),'type'=>'header'),
 				array('name'=>'one_cache','label'=>__('Show each notification'),'type'=>'select', 'values'=>array(0=>__('multiple times every login and on each device'), 1=>__('only once and only on one device')), 'default'=>1),
 				array('name'=>null,'label'=>__('Browser Notification').' - '.__('General'),'type'=>'header'),
-				array('name'=>'general_timeout', 'reload'=>1, 'label'=>__('Close Message Timeout'),'type'=>'select','values'=>Utils_CommonDataCommon::get_translated_array('Base_Notify/Timeout', true),'default'=>0),
+				array('name'=>'general_timeout', 'reload'=>1, 'label'=>__('Close Message Timeout'),'type'=>'select','values'=>Utils_CommonDataCommon::get_translated_array('Base_Notify/Timeout', 'position'),'default'=>0),
 				array('name'=>'general_group','label'=>__('Group Similar Notifications'),'type'=>'checkbox','default'=>1),
 				array('name'=>'browser_settings', 'label'=>'','type'=>'static','values'=>'<a class="button" onClick="Base_Notify.notify (\'Notification\', {body: \'enabled\', icon: \''.self::get_icon('Base_Notify').'\'}, true);">'.(__('Browser Settings')).'</a>'),
 
@@ -201,7 +201,7 @@ class Base_NotifyCommon extends ModuleCommon {
 		foreach ($modules as $module) {
 			$label = self::get_module_caption($module);
 	
-			$ret = array_merge($ret, array(array('name'=>$module.'_timeout','label'=>$label,'type'=>'select','values'=>array(-2=>_M('Use general setting')) + Utils_CommonDataCommon::get_translated_array('Base_Notify/Timeout', true),'default'=>-2)));
+			$ret = array_merge($ret, array(array('name'=>$module.'_timeout','label'=>$label,'type'=>'select','values'=>array(-2=>_M('Use general setting')) + Utils_CommonDataCommon::get_translated_array('Base_Notify/Timeout', 'position'),'default'=>-2)));
 		}
 
 		$ret[] = array('name'=>null,'label'=>__('Telegram Notification'),'type'=>'header');

--- a/modules/CRM/Common/CommonCommon_0.php
+++ b/modules/CRM/Common/CommonCommon_0.php
@@ -22,7 +22,7 @@ class CRM_CommonCommon extends ModuleCommon {
 					array('name'=>'method','label'=>__('Dialing Method'), 'type'=>'select', 'values'=>$methods, 'default'=>'none'),
 				),
 				__('Misc')=>array(
-					array('name'=>'default_record_permission','label'=>__('Default Records Permission'),'type'=>'select','default'=>0,'values'=>Utils_CommonDataCommon::get_translated_array('CRM/Access', false))
+					array('name'=>'default_record_permission','label'=>__('Default Records Permission'),'type'=>'select','default'=>0,'values'=>Utils_CommonDataCommon::get_translated_array('CRM/Access', 'key'))
 				)
 			);
 		}
@@ -45,7 +45,7 @@ class CRM_CommonCommon extends ModuleCommon {
 	}
 
 	public static function status_filter($rb) {
-		$sts = Utils_CommonDataCommon::get_translated_array('CRM/Status',true);
+		$sts = Utils_CommonDataCommon::get_translated_array('CRM/Status','position');
 		$trans = array('__NULL__'=>array(), '__NO_CLOSED__'=>array('!status'=>array(3,4)));
 		foreach ($sts as $k=>$v)
 			$trans[$k] = array('status'=>$k);

--- a/modules/CRM/Contacts/ContactsCommon_0.php
+++ b/modules/CRM/Contacts/ContactsCommon_0.php
@@ -32,7 +32,7 @@ class CRM_ContactsCommon extends ModuleCommon {
 		$me = CRM_ContactsCommon::get_my_record(); 
 		//$mc = CRM_ContactsCommon::get_main_company();
 		if ($all || $me['id']!=-1) {
-			$access_vals = Utils_CommonDataCommon::get_array('Contacts/Access', true);
+			$access_vals = Utils_CommonDataCommon::get_array('Contacts/Access', 'key');
 			if ($all) $access = array_keys($access_vals);
 			else $access = $me['access'];
 			foreach ($access as $g) {

--- a/modules/Data/Countries/CountriesCommon_0.php
+++ b/modules/Data/Countries/CountriesCommon_0.php
@@ -21,16 +21,16 @@ class Data_CountriesCommon extends Base_AdminModuleCommon {
 	public static function QFfield_country(&$form, $field, $label, $mode, $default, $desc) {
 		$param = explode('::',$desc['param']['array_id']);
 		foreach ($param as $k=>$v) if ($k!==0) $param[$k] = strtolower(str_replace(' ','_',$v));
-		$order = $desc['param']['order_by_key'];
-		$form->addElement('commondata', $field, $label, $param, array('empty_option'=>true, 'order_by_key' => $order), array('id'=>$field));
+		$order = $desc['param']['order'];
+		$form->addElement('commondata', $field, $label, $param, array('empty_option'=>true, 'order' => $order), array('id'=>$field));
 		if ($mode!=='add') $form->setDefaults(array($field=>$default));
 	}
 
 	public static function QFfield_zone(&$form, $field, $label, $mode, $default, $desc) {
 		$param = explode('::',$desc['param']['array_id']);
 		foreach ($param as $k=>$v) if ($k!==0) $param[$k] = strtolower(str_replace(' ','_',$v));
-		$order = $desc['param']['order_by_key'];
-		$form->addElement('commondata', $field, $label, $param, array('empty_option'=>true, 'order_by_key' => $order), array('id'=>$field));
+		$order = $desc['param']['order'];
+		$form->addElement('commondata', $field, $label, $param, array('empty_option'=>true, 'order' => $order), array('id'=>$field));
 		if ($mode!=='add') $form->setDefaults(array($field=>$default));
 	}
 

--- a/modules/Utils/CommonData/CommonDataCommon_0.php
+++ b/modules/Utils/CommonData/CommonDataCommon_0.php
@@ -11,6 +11,8 @@ defined("_VALID_ACCESS") || die('Direct access forbidden');
 
 class Utils_CommonDataCommon extends ModuleCommon {
 
+	public static $allowed_order = array('key', 'value', 'position');
+	
 	/**
 	 * For internal use only.
 	 */
@@ -242,7 +244,7 @@ class Utils_CommonDataCommon extends ModuleCommon {
 	 */
 	public static function get_array($name, $order='value', $readinfo=false, $silent=false){
 		static $cache;
-		$order = self::order_legacy_check($order);
+		$order = self::validate_order($order);
 		if(isset($cache[$name][$order][$readinfo]))
 			return $cache[$name][$order][$readinfo];
 		$id = self::get_id($name);
@@ -270,7 +272,7 @@ class Utils_CommonDataCommon extends ModuleCommon {
 	}
 
 	public static function get_translated_array($name,$order='value',$readinfo=false,$silent=false) {
-		$order = self::order_legacy_check($order);
+		$order = self::validate_order($order);
 		if ($readinfo) $info = self::get_array($name,$order,$readinfo,$silent);
 		$arr = self::get_array($name,$order,false,$silent);
 		if ($arr===null) return null;
@@ -287,12 +289,17 @@ class Utils_CommonDataCommon extends ModuleCommon {
 		}
 		return $arr;
 	}	
-
-	public static function order_legacy_check($order) {
-		//legacy check for $order_by_position
-		if (is_bool($order) || strlen($order) <= 1) {
-			$order = $order ? 'position' : 'value';
-		}
+	
+	/**
+	 * Validates values for commondata array order including legacy check for order_by_key.
+	 *
+	 * @param mixed order value to be validated
+	 * @return string returns valid order value as defined in Utils_CommonDataCommon::$allowed_order array
+	 */	
+	public static function validate_order($order) {
+		if (!in_array($order, self::$allowed_order, true))
+			$order = $order? 'key': 'value';
+	
 		return $order;
 	}
 

--- a/modules/Utils/CommonData/CommonDataCommon_0.php
+++ b/modules/Utils/CommonData/CommonDataCommon_0.php
@@ -242,6 +242,7 @@ class Utils_CommonDataCommon extends ModuleCommon {
 	 */
 	public static function get_array($name, $order='value', $readinfo=false, $silent=false){
 		static $cache;
+		$order = self::order_legacy_check($order);
 		if(isset($cache[$name][$order][$readinfo]))
 			return $cache[$name][$order][$readinfo];
 		$id = self::get_id($name);
@@ -269,6 +270,7 @@ class Utils_CommonDataCommon extends ModuleCommon {
 	}
 
 	public static function get_translated_array($name,$order='value',$readinfo=false,$silent=false) {
+		$order = self::order_legacy_check($order);
 		if ($readinfo) $info = self::get_array($name,$order,$readinfo,$silent);
 		$arr = self::get_array($name,$order,false,$silent);
 		if ($arr===null) return null;
@@ -284,6 +286,14 @@ class Utils_CommonDataCommon extends ModuleCommon {
 			}
 		}
 		return $arr;
+	}	
+
+	public static function order_legacy_check($order) {
+		//legacy check for $order_by_position
+		if (is_bool($order) || strlen($order) <= 1) {
+			$order = $order ? 'position' : 'value';
+		}
+		return $order;
 	}
 
 	public static function translate_array(& $arr) {

--- a/modules/Utils/CommonData/CommonData_0.php
+++ b/modules/Utils/CommonData/CommonData_0.php
@@ -107,7 +107,7 @@ class Utils_CommonData extends Module {
 					));
 
 		print('<h2>'.$name.'</h2><br>');
-		$ret = Utils_CommonDataCommon::get_translated_array($name,true,true);
+		$ret = Utils_CommonDataCommon::get_translated_array($name,'position',true);
 		foreach($ret as $k=>$v) {
 			$gb_row = $gb->get_new_row();
 			$gb_row->add_data($v['position'],$k,$v['value']); // ****** CommonData value translation

--- a/modules/Utils/CommonData/qf.php
+++ b/modules/Utils/CommonData/qf.php
@@ -31,11 +31,12 @@ class HTML_QuickForm_commondata extends HTML_QuickForm_select {
 
 		if (isset($options['empty_option']))
 			$this->_add_empty_fields = $options['empty_option'];
-		//legacy check
-		if (isset($options['order_by_key']))
-			$this->_order = Utils_CommonDataCommon::order_legacy_check($options['order_by_key']);
+		
 		if (isset($options['order']))
-			$this->_order = $options['order'];
+			$this->_order = Utils_CommonDataCommon::validate_order($options['order']);		
+		elseif (isset($options['order_by_key'])) //legacy check
+			$this->_order = Utils_CommonDataCommon::validate_order($options['order_by_key']);
+		
 		if(count($this->_cd)==1) {
 			$root_data = Utils_CommonDataCommon::get_translated_array($this->_cd[0],$this->_order);
 			if($this->_add_empty_fields)

--- a/modules/Utils/CommonData/qf.php
+++ b/modules/Utils/CommonData/qf.php
@@ -31,6 +31,9 @@ class HTML_QuickForm_commondata extends HTML_QuickForm_select {
 
 		if (isset($options['empty_option']))
 			$this->_add_empty_fields = $options['empty_option'];
+		//legacy check
+		if (isset($options['order_by_key']))
+			$this->_order = Utils_CommonDataCommon::order_legacy_check($options['order_by_key']);
 		if (isset($options['order']))
 			$this->_order = $options['order'];
 		if(count($this->_cd)==1) {

--- a/modules/Utils/CommonData/qf.php
+++ b/modules/Utils/CommonData/qf.php
@@ -14,7 +14,7 @@ require_once('HTML/QuickForm/select.php');
 class HTML_QuickForm_commondata extends HTML_QuickForm_select {
 	var $_cd = null;
 	var $_add_empty_fields = false;
-	var $_order_by_key = false;
+	var $_order = 'value';
 
 	function HTML_QuickForm_commondata($elementName=null, $elementLabel=null, $commondata=null, $options=null, $attributes=null) {
 		$this->HTML_QuickForm_select($elementName, $elementLabel, array(), $attributes);
@@ -31,10 +31,10 @@ class HTML_QuickForm_commondata extends HTML_QuickForm_select {
 
 		if (isset($options['empty_option']))
 			$this->_add_empty_fields = $options['empty_option'];
-		if (isset($options['order_by_key']))
-			$this->_order_by_key = $options['order_by_key'];
+		if (isset($options['order']))
+			$this->_order = $options['order'];
 		if(count($this->_cd)==1) {
-			$root_data = Utils_CommonDataCommon::get_translated_array($this->_cd[0],$this->_order_by_key);
+			$root_data = Utils_CommonDataCommon::get_translated_array($this->_cd[0],$this->_order);
 			if($this->_add_empty_fields)
 				$root_data = array(''=>'---')+$root_data;
 			$this->loadArray($root_data);
@@ -64,7 +64,7 @@ class HTML_QuickForm_commondata extends HTML_QuickForm_select {
 					 )) . ' />';
 				return $html;
 			}
-			eval_js('new Utils_CommonData(\''.Epesi::escapeJS($id,false).'\', \''.Epesi::escapeJS($val,false).'\', \''.Epesi::escapeJS(json_encode($this->_cd),false).'\', '.($this->_add_empty_fields?1:0).', \'' . $this->_order_by_key . '\')');
+			eval_js('new Utils_CommonData(\''.Epesi::escapeJS($id,false).'\', \''.Epesi::escapeJS($val,false).'\', \''.Epesi::escapeJS(json_encode($this->_cd),false).'\', '.($this->_add_empty_fields?1:0).', \'' . $this->_order . '\')');
 		}
 	        return parent::toHtml();
 	}

--- a/modules/Utils/RecordBrowser/QueryBuilderIntegration.php
+++ b/modules/Utils/RecordBrowser/QueryBuilderIntegration.php
@@ -188,7 +188,7 @@ class Utils_RecordBrowser_QueryBuilderIntegration
                 $array_id = is_array($f['param']) ? $f['param']['array_id'] : $f['ref_table'];
                 $values = array('' => '['.__('Empty').']');
                 if (strpos($array_id, '::') === false) {
-                    $values = $values + Utils_CommonDataCommon::get_translated_array($array_id, is_array($f['param']) ? $f['param']['order_by_key'] : false);
+                    $values = $values + Utils_CommonDataCommon::get_translated_array($array_id, is_array($f['param']) ? $f['param']['order'] : false);
                 }
                 break;
             case 'integer':     $type = 'integer'; break;
@@ -244,7 +244,7 @@ class Utils_RecordBrowser_QueryBuilderIntegration
             case $args['commondata']:
                 $array_id = is_array($args['param']) ? $args['param']['array_id'] : $args['ref_table'];
                 if (strpos($array_id, '::')===false)
-                    $arr = $arr + Utils_CommonDataCommon::get_translated_array($array_id, is_array($args['param'])?$args['param']['order_by_key']:false);
+                    $arr = $arr + Utils_CommonDataCommon::get_translated_array($array_id, is_array($args['param'])?$args['param']['order']:false);
                 break;
             case $tab=='contact' && $field=='login' ||
                  $tab=='rc_accounts' && $field=='epesi_user': // just a quickfix, better solution will be needed

--- a/modules/Utils/RecordBrowser/RecordBrowserCommon_0.php
+++ b/modules/Utils/RecordBrowser/RecordBrowserCommon_0.php
@@ -231,43 +231,29 @@ class Utils_RecordBrowserCommon extends ModuleCommon {
 	public static function decode_commondata_param($param) {
         $param = explode('__',$param);
         if (isset($param[1])) {
-            $order = $param[0];
-            // legacy check
-            if (strlen($order) <= 1) {
-                $order = $order ? 'key' : 'value';
-            }
+            $order = Utils_CommonDataCommon::validate_order($param[0]);
             $array_id = $param[1];
         } else {
-        	$array_id = $param[0];
         	$order = 'value';
+        	$array_id = $param[0];        	
         }
         return array('order'=>$order, 'order_by_key'=>$order, 'array_id'=>$array_id);
     }
-	public static function encode_commondata_param($param) {
-        if (!is_array($param)) return 'value__'.$param;
-        if (isset($param[0]) && isset($param[1])) {
-        	$param['array_id'] = implode('::', array($param[0], $param[1]));
-        	unset($param[0]);
-        	unset($param[1]);
-        }
-        if (isset($param[0])) {
-            $param['array_id'] = $param[0];
+    public static function encode_commondata_param($param) {
+    	if (!is_array($param)) 
+    		$param = array($param);
+               
+    	$order = 'value';
+        if (isset($param['order']) || isset($param['order_by_key'])) {
+        	$order = Utils_CommonDataCommon::validate_order(isset($param['order'])? $param['order']: $param['order_by_key']);
+        	
+        	unset($param['order']);
+        	unset($param['order_by_key']);
         }
         
-        $allowed_order = array('key', 'value', 'position');
-        	
-        //legacy check
-        if (isset($param['order_by_key'])) {
-        	if (in_array($param['order_by_key'], $allowed_order, true))
-        		$param['order'] = $param['order_by_key'];
-        	else 
-        		$param['order'] = $param['order_by_key']? 'key': 'value';
-        }
-        	
-        if (!isset($param['order']) || !in_array($param['order'], $allowed_order))
-        	$param['order'] = 'value';
-        	
-        return implode('__', array($param['order'], $param['array_id']));
+        $array_id = implode('::', $param);
+         
+        return implode('__', array($order, $array_id));
     }
     public static function decode_autonumber_param($param, &$prefix, &$pad_length, &$pad_mask) {
         $parsed = explode('__', $param, 4);

--- a/modules/Utils/RecordBrowser/RecordBrowserCommon_0.php
+++ b/modules/Utils/RecordBrowser/RecordBrowserCommon_0.php
@@ -228,7 +228,7 @@ class Utils_RecordBrowserCommon extends ModuleCommon {
             $ret[$w] = $w;
         return $ret;
     }
-    public static function decode_commondata_param($param) {
+	public static function decode_commondata_param($param) {
         $param = explode('__',$param);
         if (isset($param[1])) {
             $order = $param[0];
@@ -236,11 +236,12 @@ class Utils_RecordBrowserCommon extends ModuleCommon {
             if (strlen($order) <= 1) {
                 $order = $order ? 'key' : 'value';
             }
-            $param = array('order'=>$order, 'array_id'=>$param[1]);
+            $array_id = $param[1];
         } else {
-            $param = array('order'=>'value', 'array_id'=>$param[0]);
+        	$array_id = $param[0];
+        	$order = 'value';
         }
-        return $param;
+        return array('order'=>$order, 'order_by_key'=>$order, 'array_id'=>$array_id);
     }
 	public static function encode_commondata_param($param) {
         if (!is_array($param)) return 'value__'.$param;

--- a/modules/Utils/RecordBrowser/RecordBrowser_0.php
+++ b/modules/Utils/RecordBrowser/RecordBrowser_0.php
@@ -420,14 +420,14 @@ class Utils_RecordBrowser extends Module {
             } else if ($this->table_rows[$filter]['type'] == 'commondata') {
 					$parts = explode('::', $this->table_rows[$filter]['param']['array_id']);
 					$array_id = array_shift($parts);
-					$arr = Utils_CommonDataCommon::get_translated_array($array_id, $this->table_rows[$filter]['param']['order_by_key']);
+					$arr = Utils_CommonDataCommon::get_translated_array($array_id, $this->table_rows[$filter]['param']['order']);
 					$made_of_parts = false;
 					while (!empty($parts)) {
 						$made_of_parts = true;
 						array_shift($parts);
 						$next_arr = array();
 						foreach ($arr as $k=>$v) {
-							$next = Utils_CommonDataCommon::get_translated_array($array_id.'/'.$k, $this->table_rows[$filter]['param']['order_by_key']);
+							$next = Utils_CommonDataCommon::get_translated_array($array_id.'/'.$k, $this->table_rows[$filter]['param']['order']);
 							foreach ($next as $k2=>$v2)
 								$next_arr[$k.'/'.$k2] = $v.' / '.$v2;
 						}
@@ -2009,7 +2009,7 @@ class Utils_RecordBrowser extends Module {
 					if ($args['type']=='commondata') $args['type'] = 'select';
 					$param = __('Source').': CommonData'.'<br/>';
 					$param .= __('Table').': '.$args['param']['array_id'].'<br/>';
-					$param .= __('Order by').': '._V(ucfirst($args['param']['order_by_key']));
+					$param .= __('Order by').': '._V(ucfirst($args['param']['order']));
 					$args['param'] = $param;
 					break;
                 case 'time':
@@ -2183,7 +2183,7 @@ class Utils_RecordBrowser extends Module {
 					$row['select_type'] = 'select';
 					$row['data_source'] = 'commondata';
 					$param = Utils_RecordBrowserCommon::decode_commondata_param($row['param']);
-					$form->setDefaults(array('order_by'=>$param['order_by_key'], 'commondata_table'=>$param['array_id']));
+					$form->setDefaults(array('order_by'=>$param['order'], 'commondata_table'=>$param['array_id']));
 					break;
                 case 'autonumber':
                     $row['select_data_type'] = 'autonumber';
@@ -2324,7 +2324,7 @@ class Utils_RecordBrowser extends Module {
 				case 'select':
 							if ($data['data_source']=='commondata') {
 								if ($data['select_type']=='select') {
-									$param = Utils_RecordBrowserCommon::encode_commondata_param(array('order_by_key'=>$data['order_by'], 'array_id'=>$data['commondata_table']));
+									$param = Utils_RecordBrowserCommon::encode_commondata_param(array('order'=>$data['order_by'], 'array_id'=>$data['commondata_table']));
 									$data['select_data_type'] = 'commondata';
 								} else {
 									$param = '__COMMON__::'.$data['commondata_table'].'::'.$data['order_by'];


### PR DESCRIPTION
The option for commondata list ordering is now called `order`.
Legacy calls are supported for recordset field installation and using the `order_by_key` option.
The calls to `get_array` and `get_translated_array` methods of the `Utils_CommonData` class now require that `$order` argument is specifically mentioned (`key`, `position` or `value`) if not the default one (`value`).