### PR TITLE
[FIX] correct display of settings icon

### DIFF
--- a/modules/Base/Notify/NotifyCommon_0.php
+++ b/modules/Base/Notify/NotifyCommon_0.php
@@ -213,6 +213,10 @@ class Base_NotifyCommon extends ModuleCommon {
 		$ret[] = array('name'=>'telegram_url', 'label'=>'<a class="button" href="modules/Base/Notify/telegram.php" target="_blank">'.($telegram?__('Connect to another telegram account'):__('Connect to your telegram account')).'</a>','type'=>'static','values'=>($telegram?'<a class="button" '.Module::create_href(array('telegram'=>1)).'>'.__('Disconnect telegram').'</a>':''));
 
 		return array(__('Notifications')=>$ret);
+	}	
+
+	public static function user_settings_icon() {
+		return Base_ThemeCommon::get_template_file(self::module_name(),'icon.png');
 	}
 
 	public static function group_similar() {


### PR DESCRIPTION
Watchdog icon has been used as Watchdog adds setting options to the Base/Notify user settings