### PR TITLE
[FIX] do not change the Utils_RecordBrowser::$rb_obj when special display

### DIFF
--- a/modules/Utils/RecordBrowser/RecordBrowser_0.php
+++ b/modules/Utils/RecordBrowser/RecordBrowser_0.php
@@ -207,9 +207,10 @@ class Utils_RecordBrowser extends Module {
         return Utils_RecordBrowserCommon::get_access($this->tab, $action, $param);
     }
 
-    public function construct($tab = null) {
+ 	public function construct($tab = null, $special = false) {
 		Utils_RecordBrowserCommon::$options_limit = Base_User_SettingsCommon::get('Utils_RecordBrowser','enable_autocomplete');
-        self::$rb_obj = $this;
+        if (!$special)
+			self::$rb_obj = $this;
         $this->tab = & $this->get_module_variable('tab', $tab);
         if ($this->tab!==null) Utils_RecordBrowserCommon::check_table_name($this->tab);
 		load_js('modules/Utils/RecordBrowser/main.js');

--- a/modules/Utils/RecordBrowser/RecordPicker/RecordPicker_0.php
+++ b/modules/Utils/RecordBrowser/RecordPicker/RecordPicker_0.php
@@ -35,7 +35,7 @@ class Utils_RecordBrowser_RecordPicker extends Module {
 			$select_form = ob_get_clean();
 		}
 		
-		$rb = $this->init_module(Utils_RecordBrowser::module_name(), $tab, $tab.'_picker');
+		$rb = $this->init_module(Utils_RecordBrowser::module_name(), array($tab, true), $tab.'_picker');
 		$rb->adv_search = true;
 		$rb->set_filters_defaults($filters_defaults);
 		$rb->disable_actions();


### PR DESCRIPTION
Do not change the Utils_RecordBrowser::$rb_obj in case of RecordPicker (special) display.
Otherwise the variable cannot be safely used in processing callbacks