### PR TITLE
[FEATURE] RecordPicker for multiselect fields with more than one tab and crits

### DIFF
--- a/modules/Utils/RecordBrowser/RecordBrowserCommon_0.php
+++ b/modules/Utils/RecordBrowser/RecordBrowserCommon_0.php
@@ -3185,7 +3185,10 @@ class Utils_RecordBrowserCommon extends ModuleCommon {
             if ($rec_count <= Utils_RecordBrowserCommon::$options_limit) {
                 $records = array();
                 foreach($tabs as $t) {
-                    if(!empty($crits) && !$single_tab && !isset($crits[$t])) continue;
+                    if(!empty($crits) && !$single_tab && !isset($crits[$t])) {
+                    	unset($tabs[$i]);
+                    	continue;
+                    }
 
                     $access = self::get_access($t, 'selection',null,true);
                     if ($access===false) continue;
@@ -3263,7 +3266,7 @@ class Utils_RecordBrowserCommon extends ModuleCommon {
 //                natcasesort($comp);
             foreach ($records as $k => $v) {
                 if (!empty($multi_adv_params['format_callback']))
-                    $n = call_user_func($multi_adv_params['format_callback'], $v);
+                    $n = call_user_func($multi_adv_params['format_callback'], $k);
                 else {
                     if($single_tab && is_numeric($k)) {
                         $t = $tab;
@@ -3301,7 +3304,7 @@ class Utils_RecordBrowserCommon extends ModuleCommon {
                 $el = $form->addElement('automulti', $field, $label, array('Utils_RecordBrowserCommon', 'automulti_suggestbox'), array($rb_obj->tab, $crits, $f_callback, $desc['param']), $f_callback);
                 ${'rp_' . $field} = $rb_obj->init_module(Utils_RecordBrowser_RecordPicker::module_name(), array());
                 $filters_defaults = isset($multi_adv_params['filters_defaults']) ? $multi_adv_params['filters_defaults'] : array();
-                $rb_obj->display_module(${'rp_' . $field}, array($single_tab? $tab: $tabs, $field, $multi_adv_params['format_callback'], $crits, array(), array(), array(), $filters_defaults));
+                $rb_obj->display_module(${'rp_' . $field}, array($single_tab? $tab: $tabs, $field, $multi_adv_params['format_callback'], $crits_callback?:$crits, array(), array(), array(), $filters_defaults));
                 $el->set_search_button('<a ' . ${'rp_' . $field}->create_open_href() . ' ' . Utils_TooltipCommon::open_tag_attrs(__('Advanced Selection')) . ' href="javascript:void(0);"><img border="0" src="' . Base_ThemeCommon::get_template_file('Utils_RecordBrowser', 'icon_zoom.png') . '"></a>');
             } else {
                 $form->addElement('autoselect', $field, $label, $comp, array(array('Utils_RecordBrowserCommon', 'automulti_suggestbox'), array($rb_obj->tab, $crits, $f_callback, $desc['param'])), $f_callback);

--- a/modules/Utils/RecordBrowser/RecordBrowser_0.php
+++ b/modules/Utils/RecordBrowser/RecordBrowser_0.php
@@ -1026,8 +1026,8 @@ class Utils_RecordBrowser extends Module {
             if ($special) {
                 $element = $this->get_module_variable('element');
                 $format = $this->get_module_variable('format_func');
-                $formated_name = is_callable($format) ? strip_tags(call_user_func($format, $row, true)) : Utils_RecordBrowserCommon::create_default_linked_label($this->tab, $row['id'], true);
                 $row_id = $this->include_tab_in_id? $this->tab . '/' . $row['id']: $row['id'];
+                $formated_name = is_callable($format) ? strip_tags(call_user_func($format, $row_id, true)) : Utils_RecordBrowserCommon::create_default_linked_label($this->tab, $row['id'], true);
                 $row_data = array('<input type="checkbox" id="leightbox_rpicker_' . $element . '_' . $row_id . '" formated_name="' . $formated_name . '" />');
                 $rpicker_ind[] = $row_id;
             }

--- a/modules/Utils/RecordBrowser/RecordPicker/RecordPicker_0.php
+++ b/modules/Utils/RecordBrowser/RecordPicker/RecordPicker_0.php
@@ -11,30 +11,61 @@ defined("_VALID_ACCESS") || die('Direct access forbidden');
 
 class Utils_RecordBrowser_RecordPicker extends Module {
 	private $element;
+	private $crits_callback = array();
 
 	public function body($tab, $element, $format=array(), $crits=array(), $cols=array(), $order=array(), $filters=array(), $filters_defaults=array(), $custom_filters=array()) {
 		Module::$disable_confirm_leave = true;
+		
+		$refresh = false;
+		
+		$this->crits_callback = is_callable($crits)? $crits: array();
+		
+		$multi_tab = is_array($tab);		
+
+		$this->element = $element;
 
 		$select_form = '';
-		if (is_array($tab)) {
-			$tabs = array_intersect_key(Utils_RecordBrowserCommon::list_installed_recordsets(), array_flip($tab));
+		if ($this->crits_callback || is_array($tab)) {
+			$form = $this->init_module(Libs_QuickForm::module_name());		
 			
-			$form = $this->init_module(Libs_QuickForm::module_name());			
-			$form->addElement('select', 'tab', __('Recordset'), $tabs, array('id'=>'tab', 'onchange'=>$form->get_submit_form_js(), 'style'=>'width:200px'));
-			
-			if ($form->exportValue('submited')) {
-				$this->set_module_variable('tab', $form->exportValue('tab'));
+			if ($multi_tab) {
+				$tabs = array_intersect_key(Utils_RecordBrowserCommon::list_installed_recordsets(), array_flip($tab));
+				$form->addElement('select', 'tab', __('Recordset'), $tabs, array('id'=>'tab', 'onchange'=>$form->get_submit_form_js(), 'style'=>'width:200px'));
 			}
 			
-			$tab = $this->get_module_variable('tab', reset($tab));
-
-			$form->setDefaults(array('tab'=>$tab));
+			$form->addElement('hidden', 'chained_vals', 1, array('id'=>'chained_vals'));			
 			
+			if ($form->exportValue('submited')) {			
+				$this->set_module_variable($this->element . '__chained_vals', $form->exportValue('chained_vals'));
+
+				if ($multi_tab)
+					$this->set_module_variable('tab', $form->exportValue('tab'));
+				
+				$refresh = true;
+			}
+			
+			$chained_vals = $this->get_module_variable($this->element . '__chained_vals', '');
+			
+			if ($multi_tab)
+				$tab = $this->get_module_variable('tab', reset($tab));				
+
+			$form->setDefaults(array('tab'=>$tab, 'chained_vals'=>$chained_vals));				
+
 			ob_start();
-			$form->display_as_row();			
+			$form->display_as_row();
 			$select_form = ob_get_clean();
-		}
-		
+			
+			if ($this->crits_callback) {
+				parse_str($chained_vals, $chained_vals_array);
+				
+				$crits = call_user_func($this->crits_callback, false, $chained_vals_array);
+
+				if ($multi_tab) {
+					$crits = isset($crits[$tab])? $crits[$tab]: array();
+				}
+			}
+		}		
+
 		$rb = $this->init_module(Utils_RecordBrowser::module_name(), array($tab, true), $tab.'_picker');
 		$rb->adv_search = true;
 		$rb->set_filters_defaults($filters_defaults);
@@ -42,13 +73,15 @@ class Utils_RecordBrowser_RecordPicker extends Module {
 		foreach($custom_filters as $field=>$arr)
 		    $rb->set_custom_filter($field,$arr);
 
-		$this->element = $element;
-
 		Libs_LeightboxCommon::display(
 			'rpicker_leightbox_'.$element,
 			$this->get_html_of_module($rb, array($element, $format, $crits, $cols, $order, $filters, $select_form), 'recordpicker'),
 			__('Select'),
 			true);
+		
+		if ($refresh)
+			eval_js('rpicker_leightbox_refresh(\'rpicker_leightbox_'.$this->element .'\');');
+		
 		Module::$disable_confirm_leave = false;
 	}
 
@@ -59,6 +92,10 @@ class Utils_RecordBrowser_RecordPicker extends Module {
 	public function create_open_href($button=false) {
 		if(!isset($this->element))
 			trigger_error('Cannot get open link/href to record picker without packing first.',E_USER_ERROR);
+		
+		if ($this->crits_callback)
+			eval_js('rpicker_chained(\''.$this->element .'\');');
+
 		return 'rel="rpicker_leightbox_'.$this->element.'" class="lbOn'.($button?' button':'').'"';
 	}
 }

--- a/modules/Utils/RecordBrowser/rpicker.js
+++ b/modules/Utils/RecordBrowser/rpicker.js
@@ -82,3 +82,16 @@ rpicker_move = function(element, id, cstring, where){
 		}
 	}
 }
+
+rpicker_chained = function(element) {
+	jq('[rel="rpicker_leightbox_'+element+'"]').click(function(){	
+		jq('#chained_vals')
+			.val(jq('#'+element).closest('form').serialize())
+			.closest('form').submit();
+	});
+}
+
+rpicker_leightbox_refresh = function(name) {
+	leightbox_deactivate(name);
+	leightbox_activate(name);
+}


### PR DESCRIPTION
Allows for RecordPicker to be used on multiselect fields which support values from several recordsets and uses the presently edited record values to set selection list crits /if applicable/.