### PR TITLE
[UPDATE] support crits array as return value of access callback

### DIFF
--- a/modules/Utils/RecordBrowser/RecordBrowserCommon_0.php
+++ b/modules/Utils/RecordBrowser/RecordBrowserCommon_0.php
@@ -1596,7 +1596,7 @@ class Utils_RecordBrowserCommon extends ModuleCommon {
                 return false;
             } elseif ($ret !== null) {
                 if ($crits === null) {
-                    $crits = $ret;
+                    $crits = is_array($ret)? Utils_RecordBrowser_Crits::from_array($ret): $ret;
                 } else {
                     $crits = self::merge_crits($crits, $ret);
                 }


### PR DESCRIPTION
When there is only one access callback and it returns an array the value is ignored as get_access method only expects instanceof Utils_RecordBrowser_CritsInterface for the access callback crits.