### PR TITLE
[UPDATE] method for accessing RB crits

### DIFF
--- a/modules/Utils/RecordBrowser/RecordBrowser_0.php
+++ b/modules/Utils/RecordBrowser/RecordBrowser_0.php
@@ -105,6 +105,10 @@ class Utils_RecordBrowser extends Module {
     public function get_custom_defaults(){
         return $this->custom_defaults;
     }
+    
+    public function get_crits() {
+    	return $this->crits;
+    }
 
     public function get_final_crits() {
         if (!$this->displayed()) trigger_error('You need to call display_module() before calling get_final_crits() method.', E_USER_ERROR);


### PR DESCRIPTION
Introduce method to access the RB crits.
Useful when developer likes to access the filter crits for instance when using `show_filters` in an addon.