### PR TITLE
[FIX] autohide for static display

### DIFF
--- a/modules/Libs/QuickForm/autohide_fields.js
+++ b/modules/Libs/QuickForm/autohide_fields.js
@@ -21,7 +21,7 @@ Libs_QuickForm__autohide = function(e) {
 			});
 		} else if (el.attr('type') == 'checkbox') {
 			val = el.is(':checked') ? '1' : '0';
-		} else if (el.attr('type') == 'hidden') {
+		} else if (el.attr('type') == 'hidden' && el.val().indexOf('__SEP__')!== -1) {
 			val = el.val().split('__SEP__');
 			multi = true;
 		} else {


### PR DESCRIPTION
The hidden input is also used for the static display of the form fields by assigning a hidden input id=$field.'__autohide' where $field is the control field.
Assuming hidden type is only for multiselects had broken the proper autohide / autoshow of fields when form is in view mode (static display)