### PR TITLE
[FIX] default.ini location

### DIFF
--- a/modules/Base/Box/BoxCommon_0.php
+++ b/modules/Base/Box/BoxCommon_0.php
@@ -22,7 +22,7 @@ class Base_BoxCommon extends ModuleCommon {
 		elseif(file_exists($ini = Base_ThemeCommon::get_template_file('Base_Box','default.ini')))
 			return $ini;
 		else
-			$ini = __DIR__.'/default.ini';
+			$ini = 'modules/Base/Box/default.ini';
 
 		return file_exists($ini) ?$ini:null;
 	}


### PR DESCRIPTION
Using `__DIR__` does not work properly when caching of common files is enabled