### PR TITLE
[FEATURE] introduce callback option for retrieving updated chained select items

### DIFF
--- a/modules/Utils/ChainedSelect/ChainedSelectCommon_0.php
+++ b/modules/Utils/ChainedSelect/ChainedSelectCommon_0.php
@@ -11,17 +11,36 @@
 defined("_VALID_ACCESS") || die('Direct access forbidden');
 
 class Utils_ChainedSelectCommon extends ModuleCommon {
-	public static function create($dest_id,array $prev_ids,$req_url,array $params = null, $default_val=null) {
+	/**
+	 * @param string $dest_id - the id attribute of the element to enable chained select for
+	 * @param string|array $prev_ids - the id or list of ids of the fields this field is dependent upon
+	 * @param string|array $url_or_callback - a callback or file that generates the updated list of select items
+	 * Three parameters are passed to the callback: values of the previous selects, parameters, id of current element
+	 * @param array $params - parameters to pass to the callback or the generating file
+	 * @param mixed $default_val - the default value of the field
+	 */
+	public static function create($dest_id, $prev_ids, $url_or_callback,array $params = null, $default_val=null) {
+		if (is_callable($url_or_callback))
+			return self::create_callback($dest_id, $prev_ids, $url_or_callback, $params, $default_val);
+		
 		load_js('modules/Utils/ChainedSelect/cs.js');
 		if(empty($prev_ids))
 			trigger_error('Chained select can exists only with previous selects',E_USER_ERROR);
+		if (!is_array($prev_ids)) $prev_ids = array($prev_ids);
 		if($params===null) $params=array();
 		if($default_val===null) $default_val='';
 		$js = 'var params = new Hash();';
-		$_SESSION['client']['utils_chainedselect'][$dest_id] = $req_url;
+		$_SESSION['client']['utils_chainedselect'][$dest_id] = $url_or_callback;
 		foreach($params as $k=>$v)
 			$js.='params.set("'.$k.'","'.$v.'");';
-		eval_js($js.'new ChainedSelect("'.$dest_id.'",new Array("'.implode('","',$prev_ids).'"),params, "'.$default_val.'")');
+		eval_js($js.'new Utils_ChainedSelect("'.$dest_id.'",new Array("'.implode('","',$prev_ids).'"),params, "'.$default_val.'")');
+	}
+	
+	public static function create_callback($dest_id, array $prev_ids, $callback, array $params = null, $default_val=null) {
+		$params['__field__'] = $dest_id;
+		$params['__callback__'] = is_array($callback)? implode('::', $callback): $callback;
+		
+		self::create($dest_id, $prev_ids, 'modules/Utils/ChainedSelect/callback.php', $params, $default_val);
 	}
 }
 

--- a/modules/Utils/ChainedSelect/ChainedSelectCommon_0.php
+++ b/modules/Utils/ChainedSelect/ChainedSelectCommon_0.php
@@ -38,7 +38,12 @@ class Utils_ChainedSelectCommon extends ModuleCommon {
 	
 	public static function create_callback($dest_id, array $prev_ids, $callback, array $params = null, $default_val=null) {
 		$params['__field__'] = $dest_id;
-		$params['__callback__'] = is_array($callback)? implode('::', $callback): $callback;
+		$callback = is_array($callback)? implode('::', $callback): $callback;		 
+		$callback_hash = md5(serialize($callback));
+		
+		$_SESSION['client']['utils_chainedselect'][$callback_hash] = $callback;
+		
+		$params['__callback__'] = $callback_hash;
 		
 		self::create($dest_id, $prev_ids, 'modules/Utils/ChainedSelect/callback.php', $params, $default_val);
 	}

--- a/modules/Utils/ChainedSelect/callback.php
+++ b/modules/Utils/ChainedSelect/callback.php
@@ -18,7 +18,12 @@ foreach($_POST['parameters'] as $k=>$v) {
 }
 
 $field = isset($params['__field__'])? $params['__field__']: '';
-$callback = isset($params['__callback__'])? $params['__callback__']: '';
+$callback_hash = isset($params['__callback__'])? $params['__callback__']: '';
+
+$callback = array();
+if (isset($_SESSION['client']['utils_chainedselect'][$callback_hash]))
+	$callback = $_SESSION['client']['utils_chainedselect'][$callback_hash];
+
 unset($params['__field__']);
 unset($params['__callback__']);
 

--- a/modules/Utils/ChainedSelect/callback.php
+++ b/modules/Utils/ChainedSelect/callback.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * Retrieve ChainedSelect values using callback
+ * @author Georgi Hristov
+ * @copyright Copyright 2016 Georgi Hristov
+ * @license MIT
+ * @version 1.0
+ * @package Utils/ChainedSelect
+ */
+
+defined("_VALID_ACCESS") || die('Direct access forbidden');
+
+$vals = (array) $_POST['values'];
+
+$params = array();
+foreach($_POST['parameters'] as $k=>$v) {
+	$params[$k] = $v;
+}
+
+$field = isset($params['__field__'])? $params['__field__']: '';
+$callback = isset($params['__callback__'])? $params['__callback__']: '';
+unset($params['__field__']);
+unset($params['__callback__']);
+
+$res = array();
+if ($field && $callback && is_callable($callback))
+	$res = call_user_func($callback, $vals, $params, $field);
+
+if (!is_array($res)) 
+	$res = array();
+
+print(json_encode($res));
+?>

--- a/modules/Utils/ChainedSelect/cs.js
+++ b/modules/Utils/ChainedSelect/cs.js
@@ -1,5 +1,5 @@
-var ChainedSelect = Class.create();
-ChainedSelect.prototype = {
+var Utils_ChainedSelect = Class.create();
+Utils_ChainedSelect.prototype = {
 	prev_ids:null,
 	dest_id:null,
 	params:null,
@@ -74,6 +74,9 @@ ChainedSelect.prototype = {
 			onSuccess:function(t) {
 				var new_opts = t.responseText.evalJSON();
 				var obj = $(dest_id);
+				if(!jq(obj).is('select')){
+				    return;
+				}
 				var opts = obj.options;
                 if(new_opts == false) {
                     obj.setAttribute("oldDisplayValue", obj.style.display);


### PR DESCRIPTION
- introduce method for using a callback function to retrieve the chained select items
- enable using a callback or url for the default `create` method
- possibility to pass `prev_ids` parameter as string if only one previous select
- rename the jscript object to the name of the module
- add description to the `create` method