### PR TITLE
[FEATURE] change method of tooltip_id generation

### DIFF
--- a/modules/Utils/Tooltip/TooltipCommon_0.php
+++ b/modules/Utils/Tooltip/TooltipCommon_0.php
@@ -64,14 +64,12 @@ class Utils_TooltipCommon extends ModuleCommon {
 	 */
 	public static function ajax_open_tag_attrs( $callback, $args, $max_width=300 ) {
 		if(MOBILE_DEVICE) return '';
-		static $tooltip_id = 0;
-		static $tooltip_cleared = false;
-		if (isset($_REQUEST['__location']) && $tooltip_cleared!=$_REQUEST['__location']) {
-			$tooltip_cleared = $_REQUEST['__location'];
-			$tooltip_id = 0;
-		}
-		$tooltip_id++;
-		$_SESSION['client']['utils_tooltip']['callbacks'][$tooltip_id] = array('callback'=>$callback, 'args'=>$args);
+		
+		$tooltip_settings = array('callback'=>$callback, 'args'=>$args);
+		$tooltip_id = md5(serialize($tooltip_settings));
+		
+		$_SESSION['client']['utils_tooltip']['callbacks'][$tooltip_id] = $tooltip_settings;
+		
 		$loading_message = '<center><img src='.Base_ThemeCommon::get_template_file('Utils_Tooltip','loader.gif').' /><br/>'.__('Loading...').'</center>';
 		return ' onMouseMove="if(typeof(Utils_Tooltip)!=\'undefined\')Utils_Tooltip.load_ajax(this,event,'.$max_width.')" tip="'.$loading_message.'" tooltip_id="'.$tooltip_id.'" onMouseOut="if(typeof(Utils_Tooltip)!=\'undefined\')Utils_Tooltip.hide()" onMouseUp="if(typeof(Utils_Tooltip)!=\'undefined\')Utils_Tooltip.hide()" ';
 	}

--- a/modules/Utils/Tooltip/js/tooltip.js
+++ b/modules/Utils/Tooltip/js/tooltip.js
@@ -55,7 +55,6 @@ Utils_Tooltip = {
 	    Utils_Tooltip.show(o, my_event, max_width);
 		if (tooltip_id!='done' && Utils_Tooltip.timeout_obj == false) {
 	        Utils_Tooltip.timeout_obj = setTimeout(function () {
-	            o.setAttribute('tooltip_id','done');
 	            jq.ajax({
 	                type: 'POST',
 	                url: 'modules/Utils/Tooltip/req.php',
@@ -64,7 +63,9 @@ Utils_Tooltip = {
 	                    cid: Epesi.client_id
 	                },
 	                success:function(t) {
-	                    o.setAttribute('tip',t);
+	                	jq("[tooltip_id='"+ tooltip_id +"']")
+	                		.attr('tip', t)
+	                		.attr('tooltip_id', 'done');
 	                    if (t) {
 	                        jq('#tooltip_text').html(t);
 	                        if (jq('#tooltip_leightbox_mode_content').length) jq('#tooltip_leightbox_mode_content').html(t);


### PR DESCRIPTION
Here I propose a small modification in the tooltip_id generation routine.
In my case I had to modify it as I add additional html content (expand row in a table) containing tooltips with an ajax call. Using this new method generates correct tooltip_ids for the additional html.
Probably this will not be of use in the general case but the benefit is that generation of tooltip_id is more simple and taking less space in session variable as duplicate tooltip settings have same id.