### PR TITLE
[UPDATE] Libs_QuickForm__autohide

### DIFF
--- a/modules/Libs/QuickForm/QuickFormCommon_0.php
+++ b/modules/Libs/QuickForm/QuickFormCommon_0.php
@@ -37,7 +37,7 @@ class Libs_QuickFormCommon extends ModuleCommon {
 		return ' <a href="javascript:void(0);" onclick="this.parentNode.innerHTML=\'\'"><img src="'.Base_ThemeCommon::get_template_file('Libs_QuickForm','close.png').'"></a>';
 	}
 	
-	public static function autohide_fields($field, $hide_mapping) {
+	public static function autohide_fields($field_id, $hide_mapping) {
 		$allowed_modes = array('hide', 'show');
 	
 		$groups = array();
@@ -65,9 +65,9 @@ class Libs_QuickFormCommon extends ModuleCommon {
 	
 		eval_js("
 				jq(function(){
-					var hide_ctrl = jq('#$field');
+					var hide_ctrl = jq('#$field_id');
 					if(hide_ctrl.length==0) return;
-					Libs_QuickForm__hide_groups['$field']=$js_groups;
+					Libs_QuickForm__hide_groups['$field_id']=$js_groups;
 					var observer = new MutationObserver(function(mutations) {
 						mutations.forEach(function(mutation) {
 							if(mutation.addedNodes.length>0 || mutation.removedNodes.length>0 || mutation.type == 'attributes') jq('#'+mutation.target.id).trigger('change');

--- a/modules/Libs/QuickForm/QuickForm_0.php
+++ b/modules/Libs/QuickForm/QuickForm_0.php
@@ -369,23 +369,25 @@ class Libs_QuickForm extends Module {
 	 * @param mixed $default
 	 * @param array $hide_mapping array(array('values'=>array(), 'fields'=>array()), array('mode'=>[show/hide] 'values'=>array(), 'fields'=>array()))
 	 */
-	public function autohide_fields($field, $default, $hide_mapping) { //$hide_mapping =
+	public function autohide_fields($field, $default, $hide_mapping, $field_id = null) {
 		$field_obj = $this->getElement($field);
 		$field_type = $field_obj->getType();
+		$field_id = $field_id?: $field;
 	
 		$allowed_types = array('static', 'hidden', 'select', 'checkbox', 'commondata', 'text','automulti');
 		if (!in_array($field_type, $allowed_types)) throw new Exception('Cannot autohide on '.$field_type);
 	
 		if ($field_type == 'static') {
 			$field .= '__autohide';
-			$this->addElement('hidden', $field , is_array($default)?implode('__SEP__',$default):$default, 'id="' . $field . '"');
+			$field_id .= '__autohide';
+			$this->addElement('hidden', $field , is_array($default)?implode('__SEP__',$default):$default, 'id="' . $field_id . '"');
 		} elseif(is_a($field_obj,'HTML_QuickForm_multiselect')) {
-			$field.='__to';
+			$field_id .= '__to';
 		} elseif($field_type=='automulti') {
-			Libs_QuickFormCommon::autohide_fields($field.'__to', $hide_mapping);
+			Libs_QuickFormCommon::autohide_fields($field_id.'__to', $hide_mapping);
 		}
 	
-		Libs_QuickFormCommon::autohide_fields($field, $hide_mapping);
+		Libs_QuickFormCommon::autohide_fields($field_id, $hide_mapping);
 	}
 }
 ?>

--- a/modules/Libs/QuickForm/autohide_fields.js
+++ b/modules/Libs/QuickForm/autohide_fields.js
@@ -1,8 +1,8 @@
 var Libs_QuickForm__hide_groups = {};
 Libs_QuickForm__autohide = function(e) {
 	var el = jq(e.target);
-	// do not handle autohide when element is not shown
-	if (el.closest('tr').is(':hidden')) return;
+	// do not handle autohide when element is autohidden
+	if (el.hasClass('autohide')) return;
 	var hide_groups = Libs_QuickForm__hide_groups[el.attr('id')];
 	if(typeof hide_groups == "undefined") return;
 	var reverse_mode = {
@@ -45,13 +45,13 @@ Libs_QuickForm__autohide = function(e) {
 
 			if (confirmed) {
 				jq(group.fields).closest('tr')[group.mode]();
-				jq(group.fields)[group.mode](); // hide/show element to trigger nested autohide
+				jq(group.fields)[group.mode]().removeClass('auto' + reverse_mode[group.mode]).addClass('auto' + group.mode); // hide/show element to trigger nested autohide
 			}
 		} else {
 			//apply reverse mode only to fields not specifically set
 			not_set_fields = jq(group.fields).not(set_fields[group.mode]).get();
 			jq(not_set_fields).closest('tr')[reverse_mode[group.mode]]();
-			jq(not_set_fields)[reverse_mode[group.mode]](); // hide/show element to trigger nested autohide
+			jq(not_set_fields)[reverse_mode[group.mode]]().removeClass('auto' + group.mode).addClass('auto' + reverse_mode[group.mode]); // hide/show element to trigger nested autohide
 		}
 		
 		set_fields[group.mode] = group.fields;


### PR DESCRIPTION
Two commits intended to solve following problems:
- if the form is initiated in a hidden element (LeightBoxPrompt for instance) autohide elements are not set up properly due to the use of `:visible` for the element to skip the routine (intended to check if element is auto-hidden). I added solution with custom class to determine if element is really auto-hidden.
- when using multiple forms with similar fields in one page (LeightBoxPrompt with several option forms) you cannot assign the field ids same as the field name so second commit is to solve that situation.

Updates are backward compatible.