### PR TITLE
[FIX] multi leightbox creation

### DIFF
--- a/modules/Utils/FileStorage/FileLeightbox.php
+++ b/modules/Utils/FileStorage/FileLeightbox.php
@@ -20,15 +20,18 @@ class Utils_FileStorage_FileLeightbox
 
     public static function get_file_leightbox($meta, $action_urls = null, $is_history = false)
     {
+    	static $cache;
+    	
+    	$lid = 'get_file_' . md5(serialize($meta));
+    	
+    	if (isset($cache[$lid])) return $cache[$lid];
+    	
         $theme = Base_ThemeCommon::init_smarty();
 
-        $links = array();
-
-        $lid = 'get_file_' . md5(serialize($meta));
+        $links = array();        
 
         $close_leightbox_js = 'leightbox_deactivate(\'' . $lid . '\');';
         $theme->assign('download_options_id', 'attachment_download_options_' . $meta['id']);
-
 
         $file_history_key = md5(serialize($meta['id']));
         if (isset($_GET['utils_filestorage_file_history']) && $_GET['utils_filestorage_file_history'] == $file_history_key) {
@@ -85,7 +88,7 @@ class Utils_FileStorage_FileLeightbox
         $c = ob_get_clean();
 
         Libs_LeightboxCommon::display($lid, $c, __('File'));
-        return Libs_LeightboxCommon::get_open_href($lid);
+        return $cache[$lid] = Libs_LeightboxCommon::get_open_href($lid);
     }
 
 }


### PR DESCRIPTION
File leightbox is created based on file meta hash which means same file displayed several times creates duplicate leightboxes.
Introduced cache to keep track of that and avoid duplication.