### PR TITLE
[fix] get_remote method should take old link if it's available

### DIFF
--- a/modules/Utils/Attachment/AttachmentCommon_0.php
+++ b/modules/Utils/Attachment/AttachmentCommon_0.php
@@ -234,7 +234,7 @@ class Utils_AttachmentCommon extends ModuleCommon {
 	}
 
 	public static function create_remote($file_id, $description, $expires_on) {
-		$r = DB::GetRow('SELECT id, token FROM utils_attachment_download WHERE remote=1 AND attach_file_id=%d AND created_on>'.DB::DBTimeStamp(time()-3600).' AND created_by=%d',array($file_id,Acl::get_user()));
+		$r = DB::GetRow('SELECT id, token FROM utils_attachment_download WHERE remote=1 AND attach_file_id=%d AND expires_on>%T AND created_by=%d',array($file_id,time(),Acl::get_user()));
 		if (!empty($r)) {
 			$id = $r['id'];
 			$token = $r['token'];


### PR DESCRIPTION
Bug fix - we should take a link if it's available. If expire was less than 1h it leads to invalid link...