### PR TITLE
[FIX] replace id with class in defining form wrapper table

### DIFF
--- a/modules/Utils/LeightboxPrompt/theme/form.css
+++ b/modules/Utils/LeightboxPrompt/theme/form.css
@@ -1,14 +1,14 @@
 /* a */
 
-table#Utils_LeightboxPrompt__form a:hover {
+table.Utils_LeightboxPrompt__form a:hover {
 	color: #993333;
 }
 
-table#Utils_LeightboxPrompt__form .leightbox_note textarea {
+table.Utils_LeightboxPrompt__form .leightbox_note textarea {
 	width: 100%;
 }
 
-table#Utils_LeightboxPrompt__form .label {
+table.Utils_LeightboxPrompt__form .label {
 	height:17px;
 	width:100px;
 	background-color:#336699;

--- a/modules/Utils/LeightboxPrompt/theme/form.tpl
+++ b/modules/Utils/LeightboxPrompt/theme/form.tpl
@@ -1,6 +1,6 @@
 <br>
 {$form_open}
-<table id="Utils_LeightboxPrompt__form" style="border-spacing:3px;width:70%;" cellpadding="0">
+<table class="Utils_LeightboxPrompt__form" style="border-spacing:3px;width:70%;" cellpadding="0">
 	<tr>
 		<th style="width:30%;">
 		</th>


### PR DESCRIPTION
If leightbox prompt has several forms then id is not a good attribute to define for the form wrappers