### PR TITLE
[FIX] build_query $crits argument type declaration

### DIFF
--- a/modules/Utils/RecordBrowser/QueryBuilder.php
+++ b/modules/Utils/RecordBrowser/QueryBuilder.php
@@ -22,7 +22,7 @@ class Utils_RecordBrowser_QueryBuilder
         $this->admin_mode = $admin_mode;
     }
 
-    public function build_query(Utils_RecordBrowser_Crits $crits, $order = array(), $admin_filter = '')
+    public function build_query(Utils_RecordBrowser_CritsInterface $crits, $order = array(), $admin_filter = '')
     {
         $crits = $crits->replace_special_values();
 


### PR DESCRIPTION
When crits are set to a boolean Utils_RecordBrowser_Crits::from_array converts them to Utils_RecordBrowser_CritsRawSQL and when passed to Utils_RecordBrowser_QueryBuilder::build_query as first argument an error is trigerred